### PR TITLE
epic nginx fix because important nginx headers issues for proxy sites

### DIFF
--- a/Nginx.md
+++ b/Nginx.md
@@ -43,7 +43,7 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header Host $http_host;
-            proxy_set_header Connection #http_connection;
+            proxy_set_header Connection $http_connection;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_cache_bypass $http_upgrade;

--- a/Nginx.md
+++ b/Nginx.md
@@ -43,12 +43,18 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header Host $http_host;
+            proxy_set_header Connection #http_connection;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_cache_bypass $http_upgrade;
 
             proxy_redirect off;
             proxy_read_timeout 240s;  
+
+            proxy_buffer_size 128k;
+            proxy_buffers 4 256k;
+            proxy_busy_buffers_size 256k;
+            proxy_temp_file_write_size 256k;
 
             # The small block below will block googlebot
             if ($http_user_agent ~ (Googlebot)) {


### PR DESCRIPTION
hi degenerate i think that you should merge this PR because it is so important. Earlier i was trying to get proxies working for floppaaaaaaa and that guy for things p2 and it was broken! ( so sad :( ) so i think you should fix this

basically

you forgot to pass the Connection header so websocket broke! this was so important because of discord support
ALSO you forgot to set buffer stuff so discord broke again with login and TOMPHTTP! this is so important because i couldnt see my porn from money hole the entire day

please fix this :3